### PR TITLE
change mocha reporter to min.

### DIFF
--- a/scripts/mocha.opts
+++ b/scripts/mocha.opts
@@ -1,6 +1,6 @@
 --compilers js:babel-register
 --require scripts/mocha-runner
---reporter spec
+--reporter min
 --recursive
 --check-leaks
 --timeout 5000


### PR DESCRIPTION
It doesn't show passes, so you can easily see the errors since you don't have to scroll the screen.
